### PR TITLE
Version bump of nswcovid library

### DIFF
--- a/custom_components/nswcovid/manifest.json
+++ b/custom_components/nswcovid/manifest.json
@@ -6,8 +6,7 @@
   "documentation": "https://github.com/troykelly/homeassistant-au-nsw-covid/wiki",
   "issue_tracker": "https://github.com/troykelly/homeassistant-au-nsw-covid/issues",
   "requirements": [
-    "nswcovid==0.1.1",
-    "jq=>1.2.0"
+    "nswcovid==0.1.3"
   ],
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
Removing the use of jq - changing to [jello](https://github.com/kellyjonbrazil/jello)